### PR TITLE
Adding factorybot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec'
   gem 'rspec_junit_formatter'
+  gem 'shoulda-matchers', '~> 5.1'
   gem 'stub_env'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,8 +153,6 @@ GEM
     nokogiri (1.13.6-x64-mingw32)
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
-    nokogiri (1.13.6-x86_64-linux)
-      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.22.1)
     parser (3.1.2.0)
@@ -273,6 +271,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    shoulda-matchers (5.1.0)
+      activesupport (>= 5.2.0)
     slick_rails (1.5.9)
       railties (>= 3.1)
     spring (3.1.1)
@@ -348,6 +348,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  shoulda-matchers (~> 5.1)
   slick_rails
   spring
   spring-commands-rspec

--- a/app/models/dummy.rb
+++ b/app/models/dummy.rb
@@ -1,2 +1,0 @@
-class Dummy < ApplicationRecord
-end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email { 'stan@gmail.com' }
+    password { 'blah' }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  # pending "add some examples to (or delete) #{__FILE__}"
+  user1 = described_class.create(email: 'stan@gmail.com')
+  it 'is not valid without an email' do
+    user1 = build(:user, email: 'stan@gmail.com')
+    expect(user1).not_to be_valid
+  end
+
+  it 'is valid with email' do
+    user2 = build(:user, email: 'Stu@gmail.com', password: 'pickers')
+    expect(user2).to be_valid
+  end
+
+  it 'is registered' do
+    expect(user1.email).to eq 'stan@gmail.com'
+  end
+
+  #shoulda test
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_presence_of(:password) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,3 +62,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
# Release Announcement

_Behind the Scenes_
* Addition of factory bots to enable RSpec test model testing[103](https://app.shortcut.com/techgiant/story/103/add-factorybot-to-rspec-for-testing) @Toluwalope

- [ ] Release announcement note, Shortcut ticket, and relevant stakeholders

# Summary

- [ ] Set primary reviewer as assignee

# Monitoring plan
- [ ] Add your monitoring plan below. If already specified elsewhere (e.g., in a design doc, ticket etc.), link to it here.

# Testing

## Used a dummy model to test

- [ ] Describe manual tests performed using checkboxes like this one

## Unit Tests

- [ ] Describe the unit tests added using checkboxes like this one

## Admin site Tests

- [ ] If your PR makes changes to any admin site pages, or models used by the admin site

## Migration Tests

- [ ] If your PR contains a migration

